### PR TITLE
feat: add fetch wrapper and env loader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000/api

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+const schema = z.object({
+  VITE_API_URL: z.string().url(),
+})
+
+export const env = schema.parse(import.meta.env)

--- a/src/lib/fetch.js
+++ b/src/lib/fetch.js
@@ -1,0 +1,36 @@
+export async function fetchJson(url, options = {}, cfg = {}) {
+  const {
+    timeout = 8000,
+    retries = 2,
+    backoffMs = 250,
+  } = cfg
+  let attempt = 0
+  while (attempt <= retries) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeout)
+    try {
+      const res = await fetch(url, {
+        ...options,
+        signal: controller.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(options.headers || {}),
+        },
+        body:
+          options.body && typeof options.body !== 'string'
+            ? JSON.stringify(options.body)
+            : options.body,
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const text = await res.text()
+      return text ? JSON.parse(text) : null
+    } catch (err) {
+      if (attempt >= retries) throw err
+      const delay = backoffMs * 2 ** attempt + Math.random() * 100
+      await new Promise(r => setTimeout(r, delay))
+      attempt += 1
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/src/lib/fetch.test.js
+++ b/src/lib/fetch.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fetchJson } from './fetch.js'
+
+function mockResponse(body, ok = true) {
+  return {
+    ok,
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: { get: () => 'application/json' },
+  }
+}
+
+describe('fetchJson', () => {
+  it('parses JSON', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse({ ok: 1 }))
+    globalThis.fetch = mockFetch
+    const data = await fetchJson('/test')
+    expect(data).toEqual({ ok: 1 })
+  })
+
+  it('retries on failure', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(mockResponse({ ok: 1 }))
+    globalThis.fetch = mockFetch
+    const data = await fetchJson('/test', {}, { retries: 1, timeout: 100 })
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(data).toEqual({ ok: 1 })
+  })
+
+  it('times out', async () => {
+    vi.useFakeTimers()
+    const mockFetch = vi.fn((_, { signal }) =>
+      new Promise((_, reject) => {
+        signal.addEventListener('abort', () => {
+          const err = new Error('aborted')
+          err.name = 'AbortError'
+          reject(err)
+        })
+      })
+    )
+    globalThis.fetch = mockFetch
+    const p = fetchJson('/timeout', {}, { timeout: 10, retries: 0 })
+    const expectation = expect(p).rejects.toThrow()
+    await vi.advanceTimersByTimeAsync(20)
+    await expectation
+    vi.useRealTimers()
+  })
+})

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,11 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { env } from './lib/env.js'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
   </StrictMode>,
 )
+void env


### PR DESCRIPTION
## Summary
- add fetchJson utility with timeout, retries, and JSON parsing
- validate VITE_API_URL via zod schema and provide example env file
- wire env parsing into app startup and add tests for fetch wrapper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b498c538188321957766bd5fc0802d