### PR TITLE
feat: enhance mobile entries and ledger views

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -537,6 +537,9 @@ input[type=number] {
 .mov-card .currency-input .cell-input { text-align: right; }
 .mov-card .desc-input { margin-top: 6px; }
 .mov-card .saldo-caption { margin-top: 4px; font-size: 12px; color: var(--muted); text-align: right; }
+.mov-card.compact .compact-info { display: flex; justify-content: space-between; font-size: 12px; margin-top: 4px; }
+.mov-card.compact .desc-preview { flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mov-card.compact .saldo-preview { margin-left: 8px; color: var(--muted); flex-shrink: 0; }
 
 /* Entradas mobile cards */
 .ent-cards { display: grid; gap: 8px; }
@@ -544,14 +547,14 @@ input[type=number] {
 .ent-card-header { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
 .ent-card .summary { display: inline-flex; gap: 8px; font-size: 12px; color: var(--muted); }
 .ent-card .summary .val { font-weight: 600; color: var(--text); }
-.ent-card .expand-toggle { background: transparent; border: 1px solid var(--border); padding: 4px 8px; border-radius: 6px; cursor: pointer; font-size: 12px; }
+.ent-card .expand-toggle, .mov-card .expand-toggle { background: transparent; border: 1px solid var(--border); padding: 4px 8px; border-radius: 6px; cursor: pointer; font-size: 12px; }
 .ent-card .grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; margin-top: 8px; }
 .ent-card .row-title { font-weight: 600; font-size: 12px; color: var(--muted); margin-top: 6px; }
 .ent-card .date-compact-wrap { width: 80px; }
 .ent-card .date-overlay { font-size: 12px; }
 .ent-card .field-pair { display: flex; align-items: center; gap: 6px; }
 .ent-card .field-tag { font-size: 12px; color: var(--muted); white-space: nowrap; }
-.ent-card .field-pair .cell-input { flex: 1 1 auto; }
+.ent-card .field-pair .cell-input { flex: 1 1 auto; text-align: right; }
 .ent-card .date-compact-wrap { overflow: visible; }
 .ent-card .date-compact { width: 80px; }
 /* Ensure longer inline prefixes fit inside money inputs on mobile cards */

--- a/src/components/EntradasDiarias.jsx
+++ b/src/components/EntradasDiarias.jsx
@@ -257,7 +257,10 @@ export default function EntradasDiarias({ rows, onChange, activeMonth }) {
                   <div>
                     <div className="row-title">Dia</div>
                     <div className="grid">
-                      <input className="cell-input" inputMode="numeric" value={r.dia.nEntradas} onChange={e => updateShift(r.id, 'dia', 'nEntradas', e.target.value)} placeholder="Entradas" />
+                      <div className="field-pair">
+                        <span className="field-tag">Entradas</span>
+                        <input className="cell-input" inputMode="numeric" value={r.dia.nEntradas} onChange={e => updateShift(r.id, 'dia', 'nEntradas', e.target.value)} />
+                      </div>
                       <div className="currency-input"><span className="prefix">R$ Diárias</span>
                         <input className="cell-input" type="number" value={r.dia.totalEntradas} onChange={e => updateShift(r.id, 'dia', 'totalEntradas', e.target.value)} />
                       </div>
@@ -276,7 +279,10 @@ export default function EntradasDiarias({ rows, onChange, activeMonth }) {
                     </div>
                     <div className="row-title">Noite</div>
                     <div className="grid">
-                      <input className="cell-input" inputMode="numeric" value={r.noite.nEntradas} onChange={e => updateShift(r.id, 'noite', 'nEntradas', e.target.value)} placeholder="Entradas" />
+                      <div className="field-pair">
+                        <span className="field-tag">Entradas</span>
+                        <input className="cell-input" inputMode="numeric" value={r.noite.nEntradas} onChange={e => updateShift(r.id, 'noite', 'nEntradas', e.target.value)} />
+                      </div>
                       <div className="currency-input"><span className="prefix">R$ Diárias</span>
                         <input className="cell-input" type="number" value={r.noite.totalEntradas} onChange={e => updateShift(r.id, 'noite', 'totalEntradas', e.target.value)} />
                       </div>

--- a/src/components/Ledger.jsx
+++ b/src/components/Ledger.jsx
@@ -42,6 +42,7 @@ export default function Ledger({ creditTotals, activeMonth, initialItems, onItem
     if (initialItems && Array.isArray(initialItems) && initialItems.length > 0) return migrateItems(initialItems, activeMonth)
     return []
   })
+  const [expandedMovs, setExpandedMovs] = useState({})
 
   // Reset when month or initialItems change (no auto-create)
   useEffect(() => {
@@ -75,6 +76,10 @@ export default function Ledger({ creditTotals, activeMonth, initialItems, onItem
 
   function removeItem(id) {
     setItems(prev => prev.filter(it => it.id !== id))
+  }
+
+  function toggleMov(id) {
+    setExpandedMovs(prev => ({ ...prev, [id]: !prev[id] }))
   }
 
   function updateItem(id, field, value) {
@@ -189,8 +194,10 @@ export default function Ledger({ creditTotals, activeMonth, initialItems, onItem
         <div className="mov-cards">
           {sorted.length === 0 ? (
             <div className="empty-state"><p>Nenhum lançamento. Toque em "Adicionar Lançamento".</p></div>
-          ) : sorted.map((it, idx) => (
-            <div key={it.id} className="mov-card">
+          ) : sorted.map((it, idx) => {
+            const isOpen = expandedMovs[it.id] !== false
+            return (
+            <div key={it.id} className={`mov-card${isOpen ? '' : ' compact'}`}>
               <div className="mov-card-header">
                 <div className="date-compact-wrap">
                   <input
@@ -205,14 +212,26 @@ export default function Ledger({ creditTotals, activeMonth, initialItems, onItem
                 <div className="currency-input"><span className="prefix">R$</span>
                   <input type="number" inputMode="decimal" step="any" className="cell-input" value={it.valor === '' ? '' : it.valor} onChange={e => updateItem(it.id, 'valor', e.target.value)} />
                 </div>
-                <button className="link-button danger icon" aria-label="Remover" title="Remover" onClick={() => removeItem(it.id)}>✖</button>
+                <div style={{ display: 'inline-flex', gap: 6 }}>
+                  <button className="expand-toggle" onClick={() => toggleMov(it.id)}>{isOpen ? 'Recolher' : 'Expandir'}</button>
+                  <button className="link-button danger icon" aria-label="Remover" title="Remover" onClick={() => removeItem(it.id)}>✖</button>
+                </div>
               </div>
-              <div className="desc-input">
-                <input className="cell-input" value={it.descricao} onChange={e => updateItem(it.id, 'descricao', e.target.value)} placeholder="Descrição" />
-              </div>
-              <div className="saldo-caption">Saldo: R$ {typeof rowResults[idx].saldo === 'number' ? rowResults[idx].saldo.toFixed(2) : '—'}</div>
+              {isOpen ? (
+                <>
+                  <div className="desc-input">
+                    <input className="cell-input" value={it.descricao} onChange={e => updateItem(it.id, 'descricao', e.target.value)} placeholder="Descrição" />
+                  </div>
+                  <div className="saldo-caption">Saldo: R$ {typeof rowResults[idx].saldo === 'number' ? rowResults[idx].saldo.toFixed(2) : '—'}</div>
+                </>
+              ) : (
+                <div className="compact-info">
+                  <div className="desc-preview">{it.descricao || '—'}</div>
+                  <div className="saldo-preview">Saldo: R$ {typeof rowResults[idx].saldo === 'number' ? rowResults[idx].saldo.toFixed(2) : '—'}</div>
+                </div>
+              )}
             </div>
-          ))}
+          )})}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Refine mobile Entradas cards with labeled, right-aligned "Entradas" fields
- Add expandable compact mode for mobile Lançamentos cards
- Share expand toggle style across mobile cards

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9fc9a857483219ede89e5a1b8a7a0