### PR TITLE
Print resumo: inline labels in cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1015,6 +1015,12 @@ input[type="date"].date-compact::-webkit-datetime-edit { color: transparent; }
   .print-card { border: 1px solid #ddd; padding: 4px; }
   .print-card { break-inside: avoid; }
   .print-note { font-size: 9px; color: #444; margin-top: 4px; }
+  /* Compact single-row inside each resumo card */
+  .print-kv { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+  .print-kv .plabel { white-space: nowrap; }
+  .print-kv .pvalue { white-space: nowrap; }
+  /* Slightly tighter section spacing to help fit one page */
+  .print-section { margin-top: 4px; }
   .plabel { font-size: 10px; color: #333; }
   .pvalue { font-size: 11px; font-weight: 700; text-align: right; }
 

--- a/src/components/PrintSheet.jsx
+++ b/src/components/PrintSheet.jsx
@@ -103,16 +103,13 @@ export default function PrintSheet({
       <section className="print-section">
         <div className="print-grid-3">
           <div className="print-card">
-            <div className="plabel">Créditos</div>
-            <div className="pvalue">{fmt2(lancTotals.totalCreditos)}</div>
+            <div className="print-kv"><span className="plabel">Créditos</span><span className="pvalue">{fmt2(lancTotals.totalCreditos)}</span></div>
           </div>
           <div className="print-card">
-            <div className="plabel">Movimentos</div>
-            <div className="pvalue">{fmt2(lancTotals.totalMovimentos)}</div>
+            <div className="print-kv"><span className="plabel">Movimentos</span><span className="pvalue">{fmt2(lancTotals.totalMovimentos)}</span></div>
           </div>
           <div className="print-card">
-            <div className="plabel">Resultado</div>
-            <div className="pvalue">{fmt2(lancTotals.resultado)}</div>
+            <div className="print-kv"><span className="plabel">Resultado</span><span className="pvalue">{fmt2(lancTotals.resultado)}</span></div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
This PR keeps the print summary (resumo) in the original card/bubble layout, but makes each card show the label and value on a single line to save vertical space and prevent Entradas from spilling to a second page.\n\nChanges:\n- PrintSheet.jsx: Restored 3-card layout and inline key/value rows.\n- App.css (print): Added compact flex styling for the key/value rows and kept tight section spacing.\n\nNo functional logic changes; print-only layout and styles.
