### PR TITLE
docs: outline next steps for print overflow and entradas auto-fill

### DIFF
--- a/FUTURE_PLANS.md
+++ b/FUTURE_PLANS.md
@@ -1,8 +1,12 @@
 # Future Plans
 
-## Print: Lançamentos Multi‑Page Continuation
+## Print: Lançamentos Multi‑Page Continuation (Issue #19)
 
 - Goal: When there are more than 32 lançamentos in a month, continue rendering additional columns/rows on a new page instead of truncating, while keeping the layout compact and readable.
+- Next Steps:
+  - Capture overflow examples (33+ lançamentos) to compare before/after layout changes.
+  - Prototype second-page rendering keeping the existing 4×8 grid and controlled page breaks.
+  - Validate saldo behavior (continuous vs. per-chunk) with stakeholders before coding the final approach.
 - Current: We chunk lançamentos into up to 4 side‑by‑side tables with 8 rows each (max 32 rows shown); if more, a note indicates truncated count.
 - Options:
   - Continue with additional rows on the next page using a second grid of up to 4 tables; insert a controlled page break before the second grid.
@@ -19,9 +23,13 @@
 
 Code references: `src/components/PrintSheet.jsx` (lancChunks, print‑grid‑2/3/4 rendering) and `src/App.css` (print styles).
 
-## Entradas: Auto‑Fill Missing Dates on Add
+## Entradas: Auto‑Fill Missing Dates on Add (Issue #20)
 
 - Goal: When adding a new Entradas date, automatically insert any missing dates prior to the new last date so the month has no gaps.
+- Next Steps:
+  - Audit current `EntradasDiarias` helpers to list pure utilities vs. UI-specific logic before introducing auto-fill.
+  - Outline algorithm for inserting missing rows so it can be unit-tested independently of the component.
+  - Confirm UX copy for any helper messaging when multiple rows are added automatically.
 - Current:
   - “Adicionar Data” appends the next day after the latest visible date within the active month.
   - “Preencher Mês” fills all remaining days until month end upon request.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -26,10 +26,13 @@ UX/Print
 - [ ] Micro-components: `Toast`, `SummaryCards`, `PrintButton`
 - [ ] Small a11y/keyboard polish; ensure focus flows to new rows
 - [ ] Document print chunking rules in code and README
+- [ ] Print: multi-page continuation so lançamentos beyond 32 rows flow to a second sheet (#19)
+- [ ] Entradas: auto-fill intermediate dates when adding new day rows (#20)
 
 ## In Progress
 
 - Architecture: Feature folders for ledger/entradas (#10) — mapping ownership of shared helpers
+- Print: Capture overflow scenarios for regression snapshots before iterating on layout (#19)
 
 ## Issue Seeding
 
@@ -55,6 +58,7 @@ UX/Print
 ## Progress Log
 
 - 2025-09-20: Wrapped selectors, typedefs, lint/test tooling, and extracted header components; next up feature folders
+- 2025-09-20: Logged follow-up issues for print overflow continuation (#19) and entradas auto-fill gaps (#20); prep snapshot coverage for print changes
 
 ## Links
 
@@ -67,3 +71,5 @@ UX/Print
 - [UX: Extract Toast, SummaryCards, PrintButton](https://github.com/RaphaelGuerra/ledger/issues/16) (#16)
 - [A11y: Keyboard focus and labels polish](https://github.com/RaphaelGuerra/ledger/issues/17) (#17)
 - [Print: Document and centralize chunking rules](https://github.com/RaphaelGuerra/ledger/issues/18) (#18)
+- [Print: Continue lançamentos across pages when exceeding 32 rows](https://github.com/RaphaelGuerra/ledger/issues/19) (#19)
+- [Entradas: Auto-fill gaps when appending new dates](https://github.com/RaphaelGuerra/ledger/issues/20) (#20)


### PR DESCRIPTION
## Summary
- note the follow-up issues for print overflow continuation and entradas auto-fill in the improvements tracker
- capture preparatory tasks for the print continuation work in future plans and cross-link to the new issues
- expand future plans with concrete next steps for the entradas auto-fill effort and cross-link the issue

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ceaa9a4b488321b37c244a27b4cea2