### PR TITLE
Auto-fill missing entradas dates when adding

### DIFF
--- a/src/components/EntradasDiarias.jsx
+++ b/src/components/EntradasDiarias.jsx
@@ -3,6 +3,7 @@ import { formatDDMM, isoAddDays, lastDayOfMonthStr } from '../lib/date.js'
 import { useIsDesktop } from '../lib/useIsDesktop.js'
 import { toNumberOrZero, fmt2 } from '../lib/number.js'
 import { visibleEntradasRows } from '../lib/selectors.js'
+import { computeDatesToAdd } from '../lib/entradas.js'
 
 function createEmptyShift() {
   return { nEntradas: '', totalEntradas: '', cozinha: '', bar: '', outros: '' }
@@ -72,16 +73,10 @@ export default function EntradasDiarias({ rows, onChange, activeMonth }) {
 
 
   function addDateRow() {
-    // Add the earliest missing date within the active month
-    const monthStart = `${activeMonth}-01`
-    const lastDay = lastDayOfMonthStr(activeMonth)
-    const have = new Set(visibleRows.map(r => r.date).filter(Boolean))
-    let missing = null
-    for (let d = monthStart; d <= lastDay; d = isoAddDays(d, 1)) {
-      if (!have.has(d)) { missing = d; break }
-    }
-    if (!missing) return // nothing to add
-    onChange([...rows, createEmptyDateRow(missing)])
+    const datesToAdd = computeDatesToAdd(visibleRows, activeMonth)
+    if (datesToAdd.length === 0) return
+    const newRows = datesToAdd.map(createEmptyDateRow)
+    onChange([...rows, ...newRows])
   }
 
   function removeDateRow(rowId) {

--- a/src/lib/__tests__/entradas.test.js
+++ b/src/lib/__tests__/entradas.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+import { computeDatesToAdd } from '../entradas.js'
+
+describe('computeDatesToAdd', () => {
+  test('adds first day when there are no rows', () => {
+    const dates = computeDatesToAdd([], '2025-03')
+    expect(dates).toEqual(['2025-03-01'])
+  })
+
+  test('fills gaps up to next sequential date', () => {
+    const rows = [
+      { date: '2025-03-01' },
+      { date: '2025-03-03' },
+      { date: '2025-03-05' },
+    ]
+    const dates = computeDatesToAdd(rows, '2025-03')
+    expect(dates).toEqual(['2025-03-02', '2025-03-04', '2025-03-06'])
+  })
+
+  test('adds next sequential day when month has no gaps yet', () => {
+    const rows = [
+      { date: '2025-02-01' },
+      { date: '2025-02-02' },
+      { date: '2025-02-03' },
+    ]
+    const dates = computeDatesToAdd(rows, '2025-02')
+    expect(dates).toEqual(['2025-02-04'])
+  })
+
+  test('returns empty when every day of the month is present', () => {
+    const full = Array.from({ length: 29 }, (_, idx) => ({ date: `2024-02-${String(idx + 1).padStart(2, '0')}` }))
+    const fullDates = computeDatesToAdd(full, '2024-02')
+    expect(fullDates).toEqual([])
+  })
+
+  test('clamps to month end when last row already on final day', () => {
+    const rows = [
+      { date: '2025-01-01' },
+      { date: '2025-01-31' },
+    ]
+    const dates = computeDatesToAdd(rows, '2025-01')
+    expect(dates[0]).toBe('2025-01-02')
+    expect(dates.at(-1)).toBe('2025-01-30')
+    expect(dates).toHaveLength(29)
+  })
+})

--- a/src/lib/entradas.js
+++ b/src/lib/entradas.js
@@ -1,0 +1,31 @@
+import { isoAddDays, lastDayOfMonthStr } from './date.js'
+
+/**
+ * Given the visible rows for the active month, return which ISO dates should be
+ * appended when the user taps "Adicionar Data". The function guarantees that
+ * every missing day from the first day of the month up to the new last date is
+ * filled, and it never goes past the final day of the month.
+ *
+ * @param {Array<{date?: string}>} visibleRows
+ * @param {string} activeMonth YYYY-MM
+ * @returns {string[]} ISO date strings to create
+ */
+export function computeDatesToAdd(visibleRows, activeMonth) {
+  const monthStart = `${activeMonth}-01`
+  const lastDay = lastDayOfMonthStr(activeMonth)
+  const dates = (visibleRows || []).map(r => r?.date).filter(Boolean).sort()
+  const have = new Set(dates)
+
+  let target = monthStart
+  if (dates.length > 0) {
+    const last = dates[dates.length - 1]
+    const next = isoAddDays(last, 1)
+    target = next <= lastDay ? next : lastDay
+  }
+
+  const missing = []
+  for (let d = monthStart; d <= target; d = isoAddDays(d, 1)) {
+    if (!have.has(d)) missing.push(d)
+  }
+  return missing
+}


### PR DESCRIPTION
## Summary
- update "Adicionar Data" to insert all missing days up to the new last date for the active month
- add a reusable helper in `src/lib/entradas.js` with targeted unit coverage for the new date-fill rules

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ceae01c8a883218c9419a6f39e3a3c