### PR TITLE
docs: sync roadmap with recent feature deliveries

### DIFF
--- a/FUTURE_PLANS.md
+++ b/FUTURE_PLANS.md
@@ -1,50 +1,30 @@
 # Future Plans
 
-## Print: Lançamentos Multi‑Page Continuation (Issue #19)
+## Print: Lançamentos Multi‑Page Continuation (Issue #19) — ✅ Delivered
 
-- Goal: When there are more than 32 lançamentos in a month, continue rendering additional columns/rows on a new page instead of truncating, while keeping the layout compact and readable.
-- Next Steps:
-  - Capture overflow examples (33+ lançamentos) to compare before/after layout changes.
-  - Prototype second-page rendering keeping the existing 4×8 grid and controlled page breaks.
-  - Validate saldo behavior (continuous vs. per-chunk) with stakeholders before coding the final approach.
-- Current: We chunk lançamentos into up to 4 side‑by‑side tables with 8 rows each (max 32 rows shown); if more, a note indicates truncated count.
-- Options:
-  - Continue with additional rows on the next page using a second grid of up to 4 tables; insert a controlled page break before the second grid.
-  - Recompute saldo per chunk (column) vs. keep global saldo (current behavior). Global saldo is consistent across the month but can look discontinuous between chunks; per‑chunk saldo restarts at 0 each chunk.
-  - Repeat table headers on each additional grid for clarity.
-- Acceptance Criteria:
-  - Up to 32 rows fit on page 1 in at most 4 tables (8 rows each).
-  - Rows 33+ render on page 2 (and beyond) with the same 4×8 pattern.
-  - Page breaks do not split a row; headers are visible at the top of each table.
-  - Sorting remains chronological left‑to‑right then top‑to‑bottom.
-- Open Questions:
-  - Keep saldo continuous across pages or restart per page/column?
-  - Should we display a “continued…” footer/header between pages?
+- Implemented column chunking that paginates every 32 lançamentos (4 columns × 8 linhas) e adiciona quebra de página controlada.
+- Cada página repete os cabeçalhos e mantém o saldo acumulado contínuo, com aviso “Continua na próxima página…” entre páginas.
+- Users now obtêm todas as linhas na impressão sem precisar exportar manualmente.
+- Follow-ups:
+  - Validar se o aviso textual é suficiente ou se precisamos de marcador visual adicional entre páginas.
+  - Adicionar snapshot/regressão visual (ver `IMPROVEMENTS.md`, item de tooling).
 
-Code references: `src/components/PrintSheet.jsx` (lancChunks, print‑grid‑2/3/4 rendering) and `src/App.css` (print styles).
+Code references: `src/components/PrintSheet.jsx` (`lancPages`) e estilos de impressão em `src/App.css`.
 
-## Entradas: Auto‑Fill Missing Dates on Add (Issue #20)
+## Entradas: Auto‑Fill Missing Dates on Add (Issue #20) — ✅ Delivered
 
-- Goal: When adding a new Entradas date, automatically insert any missing dates prior to the new last date so the month has no gaps.
-- Next Steps:
-  - Audit current `EntradasDiarias` helpers to list pure utilities vs. UI-specific logic before introducing auto-fill.
-  - Outline algorithm for inserting missing rows so it can be unit-tested independently of the component.
-  - Confirm UX copy for any helper messaging when multiple rows are added automatically.
-- Current:
-  - “Adicionar Data” appends the next day after the latest visible date within the active month.
-  - “Preencher Mês” fills all remaining days until month end upon request.
-- Proposal:
-  - On “Adicionar Data”, detect gaps within the existing set of dates for the active month and insert any missing intermediate days up to the `nextDate` being added.
-  - Keep behavior within the active month only; do not cross months.
-- Acceptance Criteria:
-  - If the current month has dates 01, 03, 05 and the user taps “Adicionar Data”, the app creates 02, 04, and 06 (assuming 06 is the nextDate) to fill gaps.
-  - Adding when there are no gaps only inserts a single next day.
-  - Never creates dates beyond the last day of the active month.
-  - Undo/Remove continues to work per row as today.
-- Edge Cases:
-  - Months with no rows yet (start at `YYYY‑MM‑01`).
-  - Mixed empty rows and populated rows; preserve user‑entered data.
-  - Locale and disabled state (respect `addDisabled`).
+- `computeDatesToAdd` garante que “Adicionar Data” preencha todas as datas intermediárias até o próximo dia disponível do mês ativo.
+- O botão “Preencher Mês” permanece para completar o restante do mês quando desejado, agora trabalhando em conjunto com a nova lógica incremental.
+- A experiência evita lacunas acidentais e reduz cliques para meses parcialmente preenchidos.
+- Follow-ups:
+  - Considerar copy/tooltip informando quando várias datas forem criadas de uma vez.
+  - Cobrir `computeDatesToAdd` com testes unitários adicionais (já existe cobertura básica em `src/lib/entradas.test.js`).
 
-Code references: `src/components/EntradasDiarias.jsx` (visibleRows, addDateRow, fillMonth).
+Code references: `src/components/EntradasDiarias.jsx` (`addDateRow`) e `src/lib/entradas.js`.
+
+## Próximos Focos
+
+- Documentar regras de chunking de impressão diretamente no README (Issue #18).
+- Avaliar smoke tests/snapshots para garantir estabilidade visual após mudanças (ver backlog de tooling).
+- Agrupar componentes por feature (`ledger`, `entradas`) quando o ritmo de mudanças desacelerar (Issue #10).
 

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -6,7 +6,7 @@ Purpose: central place to plan, track, and log small, high‑impact upgrades whi
 
 - Scope: MVP-quality UI with clear logic; focus on maintainability and small, testable pieces.
 - Owner: @RaphaelGuerra
-- Last Updated: 2025-09-20
+- Last Updated: 2025-09-20 (post multi-page print + entradas auto-fill rollout)
 
 ## Backlog (Prioritized)
 
@@ -26,13 +26,10 @@ UX/Print
 - [ ] Micro-components: `Toast`, `SummaryCards`, `PrintButton`
 - [ ] Small a11y/keyboard polish; ensure focus flows to new rows
 - [ ] Document print chunking rules in code and README
-- [ ] Print: multi-page continuation so lançamentos beyond 32 rows flow to a second sheet (#19)
-- [ ] Entradas: auto-fill intermediate dates when adding new day rows (#20)
 
 ## In Progress
 
 - Architecture: Feature folders for ledger/entradas (#10) — mapping ownership of shared helpers
-- Print: Capture overflow scenarios for regression snapshots before iterating on layout (#19)
 
 ## Issue Seeding
 
@@ -48,6 +45,8 @@ UX/Print
 - Tooling: Minimal ESLint + Prettier config with `npm run lint` / `npm run format`
 - Tooling: Added `npm run check` for build+lint and Vitest coverage for `src/lib/`
 - Refactor: shared utils (`number`, `date`, `stats`), docs update
+- UX/Print: Multi-page continuation for lançamentos printing (#19)
+- UX/Entradas: Auto-fill missing dates when adding rows (#20)
 
 ## Decisions
 
@@ -58,7 +57,7 @@ UX/Print
 ## Progress Log
 
 - 2025-09-20: Wrapped selectors, typedefs, lint/test tooling, and extracted header components; next up feature folders
-- 2025-09-20: Logged follow-up issues for print overflow continuation (#19) and entradas auto-fill gaps (#20); prep snapshot coverage for print changes
+- 2025-09-20: Implemented multi-page print continuation (#19) e auto-fill incremental de datas nas Entradas (#20); próximos passos focam em documentação e testes visuais
 
 ## Links
 
@@ -71,5 +70,5 @@ UX/Print
 - [UX: Extract Toast, SummaryCards, PrintButton](https://github.com/RaphaelGuerra/ledger/issues/16) (#16)
 - [A11y: Keyboard focus and labels polish](https://github.com/RaphaelGuerra/ledger/issues/17) (#17)
 - [Print: Document and centralize chunking rules](https://github.com/RaphaelGuerra/ledger/issues/18) (#18)
-- [Print: Continue lançamentos across pages when exceeding 32 rows](https://github.com/RaphaelGuerra/ledger/issues/19) (#19)
-- [Entradas: Auto-fill gaps when appending new dates](https://github.com/RaphaelGuerra/ledger/issues/20) (#20)
+- ✅ [Print: Continue lançamentos across pages when exceeding 32 rows](https://github.com/RaphaelGuerra/ledger/issues/19) (#19)
+- ✅ [Entradas: Auto-fill gaps when appending new dates](https://github.com/RaphaelGuerra/ledger/issues/20) (#20)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Single‑page React app — minimal, fast, and focused on daily cash workflow.
 Detalhes de UX
 
 - Datas exibidas em DD/MM com calendário; em Entradas a Data é fixa e avança do 1º ao último dia do mês.
-- “Adicionar Data” adiciona o próximo dia; “Preencher Mês” completa todos os dias restantes do mês.
+- “Adicionar Data” preenche automaticamente quaisquer datas intermediárias faltantes até o próximo dia disponível; “Preencher Mês” completa todos os dias restantes do mês.
 - “Adicionar Lançamento” reutiliza a mesma Data do último lançamento; exige Descrição e Valor preenchidos (botão desabilita com mensagem explicativa).
 - Campos monetários têm dica “R$” e alinham à direita; totais são somente leitura com “R$”.
 
@@ -22,7 +22,7 @@ Detalhes de UX
   - Cabeçalho: logo, nome, Mês/Ano, ID (opcional) e data/hora da impressão.
   - Resumo: Créditos, Movimentos e Resultado.
   - Acumulado: Entradas (N), Diárias (R$), Média (R$), Cozinha (R$), Bar (R$), Outros (R$).
-  - Lançamentos: Data, Descrição, Valor, Saldo (apenas linhas preenchidas).
+  - Lançamentos: Data, Descrição, Valor, Saldo (apenas linhas preenchidas) com continuação automática em páginas extras quando houver mais de 32 linhas.
   - Entradas: por Data (Dia, Noite, Total) com separadores visuais e linha de total destacada.
 - Estilo tipo planilha: bordas finas, números alinhados à direita, sem sombras/cores fortes.
 - Dicas:


### PR DESCRIPTION
## Summary
- update README to document multi-page print continuation and entradas auto-fill behaviour
- refresh FUTURE_PLANS with delivered status for issues #19 and #20 plus remaining follow-ups
- move completed work to the done log in IMPROVEMENTS.md and mark related issues as finished

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ceb07386888321b729108adc56fa74